### PR TITLE
Web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Base this docker container off the official golang docker image.
 # Docker containers inherit everything from their base.
-FROM golang:1.19
+FROM alpine:edge AS build
+RUN apk add --no-cache --update go gcc g++
 
 # Create a directory inside the container to store all our application 
 # and then make it the working directory.

--- a/minitwit.go
+++ b/minitwit.go
@@ -3,16 +3,17 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/ContainerMaintainers/MiniTwit-Golang/database"
-	"github.com/ContainerMaintainers/MiniTwit-Golang/entities"
-	"github.com/ContainerMaintainers/MiniTwit-Golang/initializers"
-	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ContainerMaintainers/MiniTwit-Golang/database"
+	"github.com/ContainerMaintainers/MiniTwit-Golang/entities"
+	"github.com/ContainerMaintainers/MiniTwit-Golang/initializers"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 const Per_page int = 30
@@ -616,6 +617,7 @@ func setupRouter() *gin.Engine {
 
 	router := gin.Default()
 	router.LoadHTMLGlob("templates/*")
+	router.Static("/static", "./static/")
 
 	router.GET("/ping", ping)
 	router.GET("/", timeline)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <title>Welcome | MiniTwit</title>
-<link rel=stylesheet type=text/css href="../static/style.css">
+<link rel=stylesheet type=text/css href="/static/style.css">
 <div class=page>
   <h1>MiniTwit</h1>
   <div class=navigation>


### PR DESCRIPTION
Updated `minitwit.go` to serve file from `/static` and changed base image for webapp to save some space. Build time is still the same, but hey, it's smaller.